### PR TITLE
Add fallback value for config path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ async function getCredentials(fn){
 }
 
 var session;
-const settingsFile = path.join(process.env.HOME, '.solid-cli.json');
+const settingsFile = path.join(process.env.HOME || "", '.solid-cli.json');
 const identityManager = loadIdentityManager(settingsFile);
 const client = new SolidClient({ identityManager });
 


### PR DESCRIPTION
Otherwise libraries that use solid-auth-cli will cause a type error in the browser environment

See: https://github.com/browserify/path-browserify/blob/872fec31a8bac7b9b43be0e54ef3037e0202c5fb/index.js#L29