### PR TITLE
Better way to get User Home Directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,8 @@ async function getCredentials(fn){
 }
 
 var session;
-const settingsFile = path.join(process.env.HOME, '.solid-cli.json');
+const homedir = require('os').homedir();
+const settingsFile = path.join(homedir, '.solid-cli.json');
 const identityManager = loadIdentityManager(settingsFile);
 const client = new SolidClient({ identityManager });
 


### PR DESCRIPTION
The home directory is fetched using the native `OS` module method. 
This fixes problems on Windows where `process.env.HOME` is undefined.